### PR TITLE
Multiple ghc

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -10,10 +10,10 @@ repository cardano-haskell-packages
     d4a35cd3121aa00d18544bb0ac01c3e1691d618f462c46129271bccf39f7e8ee
 
 packages:
-  ./ytxp-sdk.cabal
+  ytxp-sdk/ytxp-sdk.cabal
 
 tests: true
 
 constraints:
-  , plutus-core == 1.20.0.0
+  , plutus-core == 1.23.0.0
 

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -13,12 +13,14 @@
         })
       ];
       pkgs = config._module.args.pkgs.extend (lib.composeManyExtensions overlays);
-      flake = pkgs.ytxp-sdk.flake { };
+      flake-96 = pkgs.ytxp-sdk-96.flake { };
+      flake-810 = pkgs.ytxp-sdk-810.flake { };
     in
     {
-      packages = with flake.packages; {
-        inherit "ytxp-sdk:lib:ytxp-sdk";
+      packages = {
+        ytxp-lib-96 = flake-96.packages."ytxp-sdk:lib:ytxp-sdk";
+        ytxp-lib-810 = flake-810.packages."ytxp-sdk:lib:ytxp-sdk";
       };
-      inherit (flake) devShells;
+      inherit (flake-96) devShells;
     };
 }

--- a/nix/project.nix
+++ b/nix/project.nix
@@ -1,7 +1,18 @@
 final: _prev: {
-  ytxp-sdk = final.haskell-nix.cabalProject' {
+  ytxp-sdk-96 = final.haskell-nix.cabalProject' {
     compiler-nix-name = "ghc96";
-    src = final.lib.cleanSource ./../ytxp-sdk;
+    src = final.lib.cleanSource ./..;
+    shell = import ./shell.nix {
+      flake = final.flake;
+      pkgs = final;
+    };
+    inputMap = {
+      "https://chap.intersectmbo.org/" = final.inputs.CHaP;
+    };
+  };
+  ytxp-sdk-810 = final.haskell-nix.cabalProject' {
+    compiler-nix-name = "ghc810";
+    src = final.lib.cleanSource ./..;
     shell = import ./shell.nix {
       flake = final.flake;
       pkgs = final;

--- a/ytxp-sdk/ytxp-sdk.cabal
+++ b/ytxp-sdk/ytxp-sdk.cabal
@@ -19,8 +19,10 @@ common common-language
     -Wall -Wcompat -fprint-explicit-foralls -fprint-explicit-kinds
     -fwarn-missing-import-lists -Weverything -Wno-unsafe
     -Wno-missing-safe-haskell-mode -Wno-implicit-prelude
-    -Wno-missing-kind-signatures -Wno-all-missed-specializations
-    -Wno-operator-whitespace
+    -Wno-all-missed-specializations
+
+  if impl(ghc >9)
+    ghc-options: -Wno-missing-kind-signatures -Wno-operator-whitespace
 
   if !flag(dev)
     ghc-options: -Werror
@@ -102,7 +104,7 @@ library
   other-modules:   Cardano.YTxP.SDK.Vendored
   build-depends:
     , aeson
-    , base               ^>=4.18.1.0
+    , base
     , base16-bytestring
     , bytestring
     , lens


### PR DESCRIPTION
- Supports for GHC8.10
- Moves cabal.project in the root directory to make cabal integration easier